### PR TITLE
Disable SVB for hi3516av200 to fix DDR instability

### DIFF
--- a/include/configs/hi3516av200.h
+++ b/include/configs/hi3516av200.h
@@ -51,7 +51,7 @@
 
 #define CONFIG_HI3516AV200		1
 
-#define CONFIG_SVB_ENABLE
+/* #define CONFIG_SVB_ENABLE */
 
 #define DDR_SCRAMB_ENABLE
 

--- a/include/configs/hi3516av200_nand.h
+++ b/include/configs/hi3516av200_nand.h
@@ -51,7 +51,7 @@
 
 #define CONFIG_HI3516AV200		1
 
-#define CONFIG_SVB_ENABLE
+/* #define CONFIG_SVB_ENABLE */
 
 #define DDR_SCRAMB_ENABLE
 


### PR DESCRIPTION
## Summary

Disable `CONFIG_SVB_ENABLE` for hi3516av200 (SPI NOR and NAND configs).

## Root cause

`start_svb()` runs at the beginning of `start_ddr_training()` and adjusts CPU/DDR voltages via HPM readings **after** the `.reg` table has already initialized DDR. This causes DDR to work at low addresses (0x81000000) but fail at higher addresses (0x88300000, TEXT_BASE), crashing the mini-boot.

The vendor firmware does not have SVB enabled — binary analysis shows zero references to the PMC register block (0x120A0000) in the vendor SPL.

## Test plan

- [x] Binary-patched SVB disable verified on real camera
- [x] Source-built with `arm-hisiv500-linux-` toolchain — boots with 512MB RAM detected
- [x] Ping verified working through PoE switch

Fixes: OpenIPC/firmware#517

🤖 Generated with [Claude Code](https://claude.com/claude-code)