### PR TITLE
Fix hi3516av200 malloc size for cold NAND boot + UBI write

### DIFF
--- a/include/configs/hi3516av200.h
+++ b/include/configs/hi3516av200.h
@@ -101,7 +101,7 @@
 #define FMC_TEXT_ADRS			(FMC_MEM_BASE)
 
 #define MEM_BASE_DDR			(DDR_MEM_BASE)
-#define CONFIG_SYS_MALLOC_LEN      (CONFIG_ENV_SIZE + 2*1024*1024)
+#define CONFIG_SYS_MALLOC_LEN      (0x40000 + 768*1024)
 /* size in bytes reserved for initial data */
 #define CONFIG_SYS_GBL_DATA_SIZE   128
 


### PR DESCRIPTION
## Summary

- The previous 2MB malloc from #5 broke cold NAND boot (#7) by overlapping the SPL's MMU page table at 0x80010000
- `hi-common.h` also silently overrides `CONFIG_ENV_SIZE` from 0x40000 to 0x10000, shrinking the effective heap from the intended 768KB to 576KB — not enough for UBI's 124KB vmalloc
- Use a literal `0x40000 + 768*1024` (1MB total) that avoids both the `CONFIG_ENV_SIZE` override and the MMU conflict

## Root cause

`hi3516av200.h` defines `CONFIG_SYS_MALLOC_LEN = CONFIG_ENV_SIZE + N`, then `#include`s `hi-common.h` which redefines `CONFIG_ENV_SIZE` from `0x40000` to `0x10000`. Since C macros are expanded at point of use (not definition), the effective heap was always smaller than intended.

## Test plan

- [x] Cold NAND boot — `System startup → Uncompress...Ok → U-Boot 2010.06` in 2.5s
- [x] Full `defib restore` with all 7 MTD partitions — all UBI writes succeed after TFTP, zero errors
- [x] Both tests on real hi3516av200 hardware with MX35LF1GE4AB SPI NAND

Closes #7

🤖 Generated with [Claude Code](https://claude.com/claude-code)