### PR TITLE
Preserve reg_info_*.bin during make clobber/distclean

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3945,6 +3945,7 @@ clean:	ddr_training.clean
 clobber:	clean
 	@find $(OBJTREE) -type f \( -name .depend \
 		-o -name '*.srec' -o -name '*.bin' -o -name u-boot.img \) \
+		! -name 'reg_info_*.bin' \
 		-print0 \
 		| xargs -0 rm -f
 	@rm -f $(OBJS) $(obj)*.bak $(obj)ctags $(obj)etags $(obj)TAGS \


### PR DESCRIPTION
## Summary

- `make clobber` (and therefore `make distclean` / `make mrproper`) was deleting the committed `reg_info_hi3516av200.bin` / `reg_info_hi3519v101.bin` source blobs at the repo root, because its `find $(OBJTREE) ... -name '*.bin'` swept them up alongside build artifacts.
- Add a single `! -name 'reg_info_*.bin'` filter to the find so the register-init source files survive a deep clean while everything else (`mini-boot.bin`, `u-boot.bin`, etc.) is still removed.
- `make clean` was never the culprit — its find pattern doesn't include `*.bin`. Only `clobber`/`distclean`/`mrproper` triggered the deletion.

## Test plan

- [ ] `ls reg_info_*.bin` shows both files present.
- [ ] After a full build (so `mini-boot.bin` and `u-boot.bin` exist at root): `make distclean` leaves both `reg_info_*.bin` in place and removes `mini-boot.bin` / `u-boot.bin`.
- [ ] `./build.sh` builds both SoCs end-to-end and `reg_info_*.bin` are still present afterwards.