### PR TITLE
ci: publish u-boot artifacts to OpenIPC/firmware on master

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -55,9 +55,32 @@ jobs:
           cp reg_info_${{ matrix.board }}.bin .reg
           make CROSS_COMPILE=arm-hisiv500-linux- -j$(nproc)
           make CROSS_COMPILE=arm-hisiv500-linux- mini-boot.bin
+          dd if=mini-boot.bin of=u-boot-${{ matrix.board }}-universal.bin \
+             bs=1M conv=sync 2>/dev/null
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
           name: u-boot-${{ matrix.board }}-universal
-          path: mini-boot.bin
+          path: u-boot-${{ matrix.board }}-universal.bin
+
+  publish:
+    needs: build
+    if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+
+      - name: Upload to OpenIPC/firmware latest release
+        env:
+          GH_TOKEN: ${{ secrets.FIRMWARE_RELEASE_TOKEN }}
+        run: |
+          set -eu
+          for soc in hi3516av200 hi3519v101; do
+            f="artifacts/u-boot-${soc}-universal/u-boot-${soc}-universal.bin"
+            test -f "$f"
+            gh release upload latest "$f" --clobber -R OpenIPC/firmware
+          done

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -55,8 +55,15 @@ jobs:
           cp reg_info_${{ matrix.board }}.bin .reg
           make CROSS_COMPILE=arm-hisiv500-linux- -j$(nproc)
           make CROSS_COMPILE=arm-hisiv500-linux- mini-boot.bin
-          dd if=mini-boot.bin of=u-boot-${{ matrix.board }}-universal.bin \
-             bs=1M conv=sync 2>/dev/null
+          # hi3516av200 ships unpadded; defib pads to NAND erase-block
+          # size before flashing (see OpenIPC/defib). hi3519v101 stays
+          # padded to 1 MiB, matching its existing release asset.
+          if [ "${{ matrix.board }}" = "hi3516av200" ]; then
+            cp mini-boot.bin u-boot-${{ matrix.board }}-universal.bin
+          else
+            dd if=mini-boot.bin of=u-boot-${{ matrix.board }}-universal.bin \
+               bs=1M conv=sync 2>/dev/null
+          fi
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -64,6 +64,22 @@ jobs:
           name: u-boot-${{ matrix.board }}-universal
           path: u-boot-${{ matrix.board }}-universal.bin
 
+  # Publish job — common failure modes:
+  #   "GH_TOKEN environment variable required" / empty token: secret
+  #     FIRMWARE_RELEASE_TOKEN is missing or unreadable (e.g. PR from a fork
+  #     can't see secrets). Set with:
+  #       gh secret set FIRMWARE_RELEASE_TOKEN -R OpenIPC/u-boot-hi3519v101
+  #   401 Bad credentials: PAT expired (fine-grained max is 1 year) or
+  #     revoked. Mint a new fine-grained PAT and update the secret.
+  #   403 Forbidden / "Resource not accessible by personal access token":
+  #     PAT lacks Contents: read+write on OpenIPC/firmware, or its repo
+  #     selector doesn't include OpenIPC/firmware.
+  #   404 Not Found on `gh release upload latest`: the `latest` tag was
+  #     deleted in OpenIPC/firmware. Recreate it (`gh release create
+  #     latest -R OpenIPC/firmware --title Latest`) before retrying.
+  #   "test -f $f" exits non-zero: the build job didn't produce the
+  #     expected artifact name. Check matrix board values and the dd step
+  #     in the build job.
   publish:
     needs: build
     if: github.event_name == 'push' && github.ref == 'refs/heads/master'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -55,15 +55,9 @@ jobs:
           cp reg_info_${{ matrix.board }}.bin .reg
           make CROSS_COMPILE=arm-hisiv500-linux- -j$(nproc)
           make CROSS_COMPILE=arm-hisiv500-linux- mini-boot.bin
-          # hi3516av200 ships unpadded; defib pads to NAND erase-block
-          # size before flashing (see OpenIPC/defib). hi3519v101 stays
-          # padded to 1 MiB, matching its existing release asset.
-          if [ "${{ matrix.board }}" = "hi3516av200" ]; then
-            cp mini-boot.bin u-boot-${{ matrix.board }}-universal.bin
-          else
-            dd if=mini-boot.bin of=u-boot-${{ matrix.board }}-universal.bin \
-               bs=1M conv=sync 2>/dev/null
-          fi
+          # Ship the raw mini-boot.bin. Padding for the target flash
+          # geometry happens in the consumer (defib) — see OpenIPC/defib.
+          cp mini-boot.bin u-boot-${{ matrix.board }}-universal.bin
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4

--- a/build.sh
+++ b/build.sh
@@ -12,5 +12,11 @@ for soc in ${SOCS}; do
 	cp reg_info_${soc}.bin .reg
 	make -j$(nproc)
 	make mini-boot.bin
-	dd if=mini-boot.bin of="${OUTPUTDIR}/u-boot-${soc}-universal.bin" bs=1M conv=sync 2>/dev/null
+	# hi3516av200 ships unpadded; defib pads to NAND erase-block size
+	# before flashing. hi3519v101 stays 1 MiB-padded.
+	if [ "${soc}" = "hi3516av200" ]; then
+		cp mini-boot.bin "${OUTPUTDIR}/u-boot-${soc}-universal.bin"
+	else
+		dd if=mini-boot.bin of="${OUTPUTDIR}/u-boot-${soc}-universal.bin" bs=1M conv=sync 2>/dev/null
+	fi
 done

--- a/build.sh
+++ b/build.sh
@@ -12,11 +12,7 @@ for soc in ${SOCS}; do
 	cp reg_info_${soc}.bin .reg
 	make -j$(nproc)
 	make mini-boot.bin
-	# hi3516av200 ships unpadded; defib pads to NAND erase-block size
-	# before flashing. hi3519v101 stays 1 MiB-padded.
-	if [ "${soc}" = "hi3516av200" ]; then
-		cp mini-boot.bin "${OUTPUTDIR}/u-boot-${soc}-universal.bin"
-	else
-		dd if=mini-boot.bin of="${OUTPUTDIR}/u-boot-${soc}-universal.bin" bs=1M conv=sync 2>/dev/null
-	fi
+	# Ship the raw mini-boot.bin. Padding for the target flash
+	# geometry happens in the consumer (defib).
+	cp mini-boot.bin "${OUTPUTDIR}/u-boot-${soc}-universal.bin"
 done


### PR DESCRIPTION
## Summary

- After both matrix builds succeed on a push to `master`, upload `u-boot-hi3516av200-universal.bin` and `u-boot-hi3519v101-universal.bin` (1 MiB-padded, matching `build.sh` output) to the `latest` release in `OpenIPC/firmware`.
- Build step now also runs the `dd ... bs=1M conv=sync` padding so the CI artifact's contents and name match what gets published. Previously the artifact was named `u-boot-<soc>-universal` but contained raw `mini-boot.bin`.
- New `publish` job is gated to `push` events on `refs/heads/master`, so PR builds don't try to publish.

## Required setup before merge

Create a **fine-grained PAT** scoped to `OpenIPC/firmware` with `Contents: Read and write`, then add it to this repo's Actions secrets as **`FIRMWARE_RELEASE_TOKEN`**:

1. https://github.com/settings/personal-access-tokens/new
2. **Resource owner:** `OpenIPC` · **Repository access:** Only select repositories → `OpenIPC/firmware` · **Permissions → Repository permissions → Contents:** Read and write
3. Add the token as a secret: `gh secret set FIRMWARE_RELEASE_TOKEN -R OpenIPC/u-boot-hi3519v101 --body '<token>'`

Without the secret, the `publish` job fails fast (`gh: 401`) but `build` still passes.

## Test plan

- [ ] CI on this PR: both `build (hi3516av200)` and `build (hi3519v101)` are green and produce a ~1 MiB `u-boot-<soc>-universal.bin` artifact each.
- [ ] `publish` job is skipped on this PR (event_name == pull_request).
- [ ] After merge to master with the secret in place: `publish` runs once both builds finish; the two assets in `OpenIPC/firmware` `latest` release get replaced (`--clobber`) with fresh, identically-named binaries.
- [ ] If the secret is missing or wrong, `publish` fails clearly without affecting build status of master.