### PR TITLE
ci: retry firmware uploads on transient 5xx

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -96,8 +96,24 @@ jobs:
           GH_TOKEN: ${{ secrets.FIRMWARE_RELEASE_TOKEN }}
         run: |
           set -eu
+          # Releases API occasionally returns 502/503 ("Unicorn!" page).
+          # Retry with backoff: 10s, 20s, 30s, 40s — total ~100s before
+          # giving up. Auth/scope errors (401/403) won't recover with a
+          # retry but we don't bother distinguishing; they fail the same
+          # way after exhausting attempts.
+          upload() {
+            local f="$1" i
+            for i in 1 2 3 4 5; do
+              if gh release upload latest "$f" --clobber -R OpenIPC/firmware; then
+                return 0
+              fi
+              [ "$i" = "5" ] && return 1
+              echo "upload attempt $i failed; sleeping $((i*10))s" >&2
+              sleep $((i*10))
+            done
+          }
           for soc in hi3516av200 hi3519v101; do
             f="artifacts/u-boot-${soc}-universal/u-boot-${soc}-universal.bin"
             test -f "$f"
-            gh release upload latest "$f" --clobber -R OpenIPC/firmware
+            upload "$f"
           done


### PR DESCRIPTION
## Summary

- The first `publish` run after PR #12 merged failed because the GitHub Releases API returned a 502 "Unicorn!" page on the very first `gh release upload` call. A manual re-run worked. Add retry to make this self-heal.
- Wrap `gh release upload` in a 5-attempt loop with linear backoff (10s, 20s, 30s, 40s — ~100s total before giving up). Real auth/scope failures still fail the job; they just take longer to surface.

## Test plan

- [ ] PR build (no publish) stays green.
- [ ] After merge, normal master push uploads both assets on the first attempt as before.
- [ ] Manual sanity: temporarily point the upload at a bogus release tag; confirm 5 attempts then fail.