### PR TITLE
ci: add QEMU smoke test to gate publish

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -65,6 +65,90 @@ jobs:
           name: u-boot-${{ matrix.board }}-universal
           path: u-boot-${{ matrix.board }}-universal.bin
 
+  # QEMU smoke test — gates publish on actually-bootable binaries.
+  # Boots each freshly-built u-boot in widgetii/qemu-hisilicon's
+  # matching machine model at default RAM and asserts it prints past
+  # the legacy "System startup" banner.
+  qemu_smoke:
+    needs: build
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        # Both Hi3516AV200 and Hi3519V101 are Cortex-A7 with 256 MiB
+        # default RAM in widgetii/qemu-hisilicon — TEXT_BASE 0x88400000
+        # fits, no -m override needed.
+        include:
+          - { board: hi3516av200, machine: hi3516av200 }
+          - { board: hi3519v101, machine: hi3519v101 }
+    steps:
+      - name: Install QEMU build deps
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y -qq --no-install-recommends \
+            build-essential ninja-build meson pkg-config \
+            libglib2.0-dev libpixman-1-dev libfdt-dev zlib1g-dev \
+            libslirp-dev python3 python3-venv
+
+      - name: Resolve qemu-hisilicon HEAD
+        id: qemu-rev
+        run: |
+          sha=$(git ls-remote https://github.com/widgetii/qemu-hisilicon master | cut -f1)
+          echo "sha=$sha" >> "$GITHUB_OUTPUT"
+
+      - name: Cache qemu-system-arm
+        id: cache-qemu
+        uses: actions/cache@v4
+        with:
+          path: qemu-arm
+          key: qemu-hisilicon-${{ steps.qemu-rev.outputs.sha }}
+
+      - name: Build qemu-system-arm (cache miss)
+        if: steps.cache-qemu.outputs.cache-hit != 'true'
+        run: |
+          git clone --depth 1 --branch master \
+            https://github.com/widgetii/qemu-hisilicon qemu-hisilicon
+          cd qemu-hisilicon
+          bash qemu/setup.sh
+          cp qemu-src/build/qemu-system-arm "$GITHUB_WORKSPACE/qemu-arm"
+          chmod +x "$GITHUB_WORKSPACE/qemu-arm"
+
+      - name: Download u-boot artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: u-boot-${{ matrix.board }}-universal
+
+      - name: Smoke-test in QEMU
+        timeout-minutes: 2
+        run: |
+          UBOOT="$PWD/u-boot-${{ matrix.board }}-universal.bin"
+          test -f "$UBOOT"
+          dd if=/dev/zero of=/tmp/flash.bin bs=1M count=8 2>/dev/null
+          dd if="$UBOOT" of=/tmp/flash.bin bs=1 conv=notrunc 2>/dev/null
+          mkfifo /tmp/uart.in /tmp/uart.out
+          chmod +x ./qemu-arm
+          ./qemu-arm \
+            -M ${{ matrix.machine }} \
+            -global hisi-fmc.flash-file=/tmp/flash.bin \
+            -nographic -serial pipe:/tmp/uart \
+            -monitor none > /tmp/qemu.log 2>&1 &
+          QEMU_PID=$!
+          timeout 10 cat /tmp/uart.out > /tmp/uboot.txt || true
+          kill "$QEMU_PID" 2>/dev/null || true
+          wait 2>/dev/null || true
+          echo "== captured u-boot output =="
+          cat /tmp/uboot.txt
+          echo
+          if grep -qE 'U-Boot |Hit any key|CPU:|DRAM:|Board:' /tmp/uboot.txt; then
+            echo "PASS: u-boot booted past System startup"
+          else
+            echo "FAIL: u-boot did not get past System startup"
+            echo
+            echo "== qemu stderr =="
+            tail -40 /tmp/qemu.log || true
+            exit 1
+          fi
+
   # Publish job — common failure modes:
   #   "GH_TOKEN environment variable required" / empty token: secret
   #     FIRMWARE_RELEASE_TOKEN is missing or unreadable (e.g. PR from a fork
@@ -82,7 +166,7 @@ jobs:
   #     expected artifact name. Check matrix board values and the dd step
   #     in the build job.
   publish:
-    needs: build
+    needs: [build, qemu_smoke]
     if: github.event_name == 'push' && github.ref == 'refs/heads/master'
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Brings hi3519v101 in line with cv300/cv200: build qemu-system-arm from widgetii/qemu-hisilicon (cached by HEAD SHA) and smoke-test each freshly-built u-boot in its matching machine before publish. Both SoCs boot cleanly at the machine default 256 MiB RAM (verified locally).

Also serves as a sanity check on the rotated FIRMWARE_RELEASE_TOKEN org secret — the publish step on master after merge will be the first real exercise of the new token from this repo's perspective.