### PR TITLE
ci: use unified -M $machine,flash-file=$f syntax (qemu-hisilicon#80)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -143,8 +143,7 @@ jobs:
           mkfifo /tmp/uart.in /tmp/uart.out
           chmod +x ./qemu-arm
           ./qemu-arm \
-            -M ${{ matrix.machine }} \
-            -global hisi-fmc.flash-file=/tmp/flash.bin \
+            -M ${{ matrix.machine }},flash-file=/tmp/flash.bin \
             -nographic -serial pipe:/tmp/uart \
             -monitor none > /tmp/qemu.log 2>&1 &
           QEMU_PID=$!


### PR DESCRIPTION
## Summary

widgetii/qemu-hisilicon#80 / #81 added a machine-level `flash-file`
property that forwards to whichever flash controller the SoC config
wires up. The CI workflow no longer needs to know controller names.

Replaces:
```
-M $machine \\
-global hisi-fmc.flash-file=$f \\
```
(or the `hisi-sfc350` variant) with the uniform:
```
-M $machine,flash-file=$f \\
```

Identical smoke step across all 8 OpenIPC HiSi u-boot workflows now.

## Test plan

- [ ] CI `qemu_smoke` job passes on every matrix entry — same
      `PASS: u-boot booted past System startup` output as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)